### PR TITLE
Make datestamps in pointer filenames configurable

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -223,12 +223,16 @@
 
       ! write pointer (path/file)
       if (my_task == master_task) then
-#ifdef CESMCOUPLED
-            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
-                 'rpointer.ice'//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
+#ifdef CESMCOUPLED 
+            lpointer_file = 'rpointer.ice'//trim(inst_suffix)
 #else
             lpointer_file = pointer_file
 #endif
+         if (pointer_date) then
+            ! append date to pointer filename
+            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
+               trim(lpointer_file)//'.',myear,'-',mmonth,'-',mday,'-',msec
+         end if
          open(nu_rst_pointer,file=lpointer_file)
          write(nu_rst_pointer,'(a)') filename
          close(nu_rst_pointer)

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -31,7 +31,7 @@ module ice_comp_nuopc
   use ice_fileunits      , only : nu_diag, nu_diag_set, inst_index, inst_name
   use ice_fileunits      , only : inst_suffix, release_all_fileunits, flush_fileunit
   use ice_restart_shared , only : runid, runtype, restart, use_restart_time, restart_dir, restart_file, &
-                                  restart_format, restart_chunksize , pointer_date
+                                  restart_format, restart_chunksize, pointer_date
   use ice_history        , only : accum_hist
   use ice_history_shared , only : history_format, history_chunksize
   use ice_exit           , only : abort_ice

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -30,7 +30,8 @@ module ice_comp_nuopc
   use ice_kinds_mod      , only : dbl_kind, int_kind, char_len, char_len_long
   use ice_fileunits      , only : nu_diag, nu_diag_set, inst_index, inst_name
   use ice_fileunits      , only : inst_suffix, release_all_fileunits, flush_fileunit
-  use ice_restart_shared , only : runid, runtype, restart, use_restart_time, restart_dir, restart_file, restart_format, restart_chunksize
+  use ice_restart_shared , only : runid, runtype, restart, use_restart_time, restart_dir, restart_file, &
+                                  restart_format, restart_chunksize , pointer_date
   use ice_history        , only : accum_hist
   use ice_history_shared , only : history_format, history_chunksize
   use ice_exit           , only : abort_ice
@@ -322,6 +323,17 @@ contains
     if (isPresent .and. isSet) then
        if (trim(cvalue) .eq. '.true.') restart_eor = .true.
     endif
+
+#ifdef CESMCOUPLED
+    ! set CICE internal pointer_date variable based on nuopc settings
+    ! this appends a datestamp to the "rpointer" file (by default this is on)
+    pointer_date = .true.
+    call NUOPC_CompAttributeGet(gcomp, name="restart_pointer_append_date", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       if (trim(cvalue) .eq. '.false.') pointer_date = .false.
+    endif
+#endif
 
     !----------------------------------------------------------------------------
     ! generate local mpi comm

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -325,16 +325,14 @@ contains
     endif
 
 #ifdef CESMCOUPLED
-    ! set CICE internal pointer_date variable based on nuopc settings
-    ! this appends a datestamp to the "rpointer" file (by default this is on)
     pointer_date = .true.
-    call NUOPC_CompAttributeGet(gcomp, name="restart_pointer_append_date", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (isPresent .and. isSet) then
-       if (trim(cvalue) .eq. '.false.') pointer_date = .false.
-    endif
 #endif
 
+    ! set CICE internal pointer_date variable based on nuopc settings
+    ! this appends a datestamp to the "rpointer" file
+    call NUOPC_CompAttributeGet(gcomp, name="restart_pointer_append_date", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) pointer_date = (trim(cvalue) .eq. ".true.")
     !----------------------------------------------------------------------------
     ! generate local mpi comm
     !----------------------------------------------------------------------------

--- a/cicecore/shared/ice_restart_shared.F90
+++ b/cicecore/shared/ice_restart_shared.F90
@@ -25,6 +25,9 @@
       character (len=char_len_long), public :: &
          pointer_file      ! input pointer file for restarts
 
+      logical (kind=log_kind), public :: &
+         pointer_date =  .false.   ! if true, append datestamp to pointer file
+
       character (len=char_len), public :: &
          restart_format      , & ! format of restart files 'nc'
          restart_rearranger      ! restart file rearranger, box or subset for pio


### PR DESCRIPTION
This adds support in cice for the addition of datestamps to the pointer filenames to be configured through the nuopc option _restart_pointer_append_date_ .

Contributes to https://github.com/COSIMA/access-om3/issues/237

