### PR TITLE
Use area ice ('ai') fluxes for ice -> ocn coupling

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -949,6 +949,7 @@ contains
     integer                    :: mon_sync   ! Sync current month
     integer                    :: day_sync   ! Sync current day
     integer                    :: tod_sync   ! Sync current time of day (sec)
+    integer                    :: nsteps     ! Number of model timeteps per coupling timestep
     character(char_len_long)   :: restart_date
     character(char_len_long)   :: restart_filename
     logical                    :: isPresent, isSet
@@ -1115,7 +1116,12 @@ contains
     !--------------------------------
 
     if(profile_memory) call ESMF_VMLogMemInfo("Entering CICE_Run : ")
-    call CICE_Run()
+
+    nsteps = INT(dt / dtime) 
+    do i=1, nsteps
+      call CICE_Run()
+    end do
+    
     if(profile_memory) call ESMF_VMLogMemInfo("Leaving CICE_Run : ")
 
     !--------------------------------

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -950,6 +950,7 @@ contains
     integer                    :: day_sync   ! Sync current day
     integer                    :: tod_sync   ! Sync current time of day (sec)
     integer                    :: nsteps     ! Number of model timeteps per coupling timestep
+    integer                    :: cpl_dt     ! Coupling timestep in seconds
     character(char_len_long)   :: restart_date
     character(char_len_long)   :: restart_filename
     logical                    :: isPresent, isSet
@@ -1116,8 +1117,8 @@ contains
     !--------------------------------
 
     if(profile_memory) call ESMF_VMLogMemInfo("Entering CICE_Run : ")
-
-    nsteps = INT(dt / dtime) 
+    call ESMF_TimeIntervalGet(timeStep, s=cpl_dt)
+    nsteps = INT(cpl_dt / dt) 
     do k=1, nsteps
       call CICE_Run()
     end do

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -1118,7 +1118,7 @@ contains
     if(profile_memory) call ESMF_VMLogMemInfo("Entering CICE_Run : ")
 
     nsteps = INT(dt / dtime) 
-    do i=1, nsteps
+    do k=1, nsteps
       call CICE_Run()
     end do
     


### PR DESCRIPTION
Coupling requires the average flux over the entire grid cell, as opposed to fluxes averaged over the ice area ("local" fluxes). Previously we used the "local" fluxes and scaled these by the ice fraction at the end of the time step to obtain grid cell averaged fluxes. This does not conserve fluxes when small ice areas are zapped - the ice fraction goes to zero and these fluxes are lost.

This PR uses the correct '_ai' fluxes avoiding this issue.
