### PR TITLE
Add CM3 meltpond coupling

### DIFF
--- a/cicecore/drivers/access/cmeps/CICE_InitMod.F90
+++ b/cicecore/drivers/access/cmeps/CICE_InitMod.F90
@@ -50,6 +50,8 @@ contains
          file=__FILE__,line= __LINE__)
 
     call input_data           ! namelist variables
+    call access_verify_inputs
+
     call input_zbgc           ! vertical biogeochemistry namelist
     call count_tracers        ! count tracers
 
@@ -463,6 +465,28 @@ contains
          file=__FILE__, line=__LINE__)
   end subroutine init_restart
 
+  !=======================================================================
+
+  subroutine access_verify_inputs()
+    ! Check required namelist settings for ACCESS CM3
+    logical(kind=log_kind) :: &
+        tr_pond_lvl
+    character(len=*), parameter :: subname = '(access_verify_inputs)'
+
+
+    call icepack_query_tracer_flags(tr_pond_lvl_out=tr_pond_lvl)
+    call icepack_warnings_flush(nu_diag)
+    if (icepack_warnings_aborted()) call abort_ice(trim(subname), &
+         file=__FILE__,line= __LINE__)
+
+    if (tr_pond_lvl) then
+        write(nu_diag,*) subname//' ERROR: Wrong meltpond scheme selected'
+        write(nu_diag,*) subname//' ERROR: tr_pond_lvl = ', tr_pond_lvl
+        call abort_ice (error_message=subname//' Level pond scheme not supported in ACCESS CM3 coupling', &
+        file=__FILE__, line=__LINE__)
+    end if
+
+  end subroutine access_verify_inputs
   !=======================================================================
 
 end module CICE_InitMod

--- a/cicecore/drivers/access/cmeps/ice_import_export.F90
+++ b/cicecore/drivers/access/cmeps/ice_import_export.F90
@@ -2073,8 +2073,8 @@ contains
       call state_setexport(exportState, 'ia_aicen', input=aicen , lmask=tmask, ifrac=ailohi, rc=rc, index=n, ungridded_index=n)
       call state_setexport(exportState, 'ia_snown', input=vsnon , lmask=tmask, ifrac=ailohi, rc=rc, index=n, ungridded_index=n)
       call state_setexport(exportState, 'ia_thikn', input=vicen , lmask=tmask, ifrac=ailohi, rc=rc, index=n, ungridded_index=n)
-      ! call state_setexport(exportState, 'ia_pndfn', input=apeffn, lmask=tmask, ifrac=ailohi, rc=rc, index=n, ungridded_index=n)
-      ! call state_setexport(exportState, 'ia_pndtn', input=trcrn(:,:,nt_hpnd,:,:), lmask=tmask, ifrac=ailohi, rc=rc, index=n, ungridded_index=n)
+      call state_setexport(exportState, 'ia_pndfn', input=apeffn, lmask=tmask, ifrac=ailohi, rc=rc, index=n, ungridded_index=n)
+      call state_setexport(exportState, 'ia_pndtn', input=trcrn(:,:,nt_hpnd,:,:), lmask=tmask, ifrac=ailohi, rc=rc, index=n, ungridded_index=n)
    end do
 
    call state_setexport(exportState, 'sstfrz', input=Tf , lmask=tmask, ifrac=ailohi, rc=rc)


### PR DESCRIPTION
This pull request adds the CICE changes required for coupling meltponds in CM3. See https://github.com/ACCESS-NRI/dev_coupling/issues/37 for discussion behind these changes and results from short simulations.

Changes in this PR include:
- aborting from the access driver if `tr_pond_lvl=.true.`. This is done as `apeffn` is not calculated when `tr_pond_lvl=.true.` and `calc_Tsfc=.False.` (see [here](https://github.com/ACCESS-NRI/Icepack/blob/1a08966a56ee2d0fcecd187d148ae612815fa539/columnphysics/icepack_shortwave.F90#L4231-L4265)
- Pond fractions are scaled by ice fractions and pond depths are scaled by pond grid-cell fractions prior to exporting. This is done to produce sensible averages which preserve pond areas and volumes after unscaling in the atmosphere.


