### PR TITLE
Use agreed upon filename for cice grid

### DIFF
--- a/cicecore/cicedyn/analysis/ice_history_shared.F90
+++ b/cicecore/cicedyn/analysis/ice_history_shared.F90
@@ -824,14 +824,14 @@
                        iyear,'.',trim(suffix)
               elseif (histfreq(ns) == 'g') then
                  write(ncfile,'(a,a,a,a)')  &
-                       history_file(1:lenstr(history_file)),'_grid', &
+                       history_file(1:lenstr(history_file)),'.static', &
                        '.',trim(suffix)
               endif
 
            else                     ! instantaneous
               if (histfreq(ns) == 'g') then
                  write(ncfile,'(a,a,a,a)')  &
-                       history_file(1:lenstr(history_file)),'_grid', &
+                       history_file(1:lenstr(history_file)),'.static', &
                        '.',trim(suffix)
               else
                  write(ncfile,'(a,a,i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &


### PR DESCRIPTION
Change grid file from:

`access-om3.cice_grid.nc` to `access-om3.cice.static.nc`

(follows https://github.com/ACCESS-NRI/access-om3-configs/issues/374#issuecomment-2750096126)